### PR TITLE
Adds GPU(full) vs CPU(tiny) guidance.

### DIFF
--- a/data182-hw04.ipynb
+++ b/data182-hw04.ipynb
@@ -1153,7 +1153,7 @@
    "outputs": [],
    "source": [
     "# Initialize MAE model\n",
-    "# GPU(full): 10 mins (12 batches/sec)\n",
+    "# GPU(full): 10 mins (30 secs per epoch)\n",
     "# CPU(full): 240 mins (12 mins per epoch)\n",
     "# CPU(tiny): 20 mins (1 min per epoch)\n",
     "# RECOMMEND_GPU_T4_FULL\n",


### PR DESCRIPTION
Adds GPU(full) vs CPU(tiny) guidance.

For each cell where students have to train a model, I've provided a default "tiny" model arch configuration where it can train reasonably quickly on a CPU instance (`RECOMMEND_CPU_TINY`). Then, when they're ready to train on full model size, they can uncomment out the `RECOMMEND_GPU_T4_FULL` code blocks.

Modifies the `ClassificationViT` class to add `n_layers, feedforward_dim` constructor args to pass to `Transformer()`.

Adds some minor clarifications/print-stmts to ease debugging.